### PR TITLE
Fix small-screen overflow of timer controls and workout log display

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
     letter-spacing:.3px;
     cursor:pointer; user-select:none;
     transition: transform .03s ease, background .15s ease, border-color .15s ease;
+    white-space: nowrap;
   }
   .btn:active{transform: scale(0.98);}
   .btn-primary{
@@ -381,9 +382,10 @@
   }
 
   @media (max-width: 560px){
-    .row{gap:10px}
+    .row{gap:10px; flex-wrap:wrap}
     .btn{padding:11px 16px}
     .btn-subtle{padding:10px 16px}
+    .btn-primary{min-width:0}
     .footer-links{
       flex-wrap: wrap;
       justify-content: space-between;
@@ -833,11 +835,13 @@
     const key = 'log-'+todaysKey();
     store.set(key, items);
   }
-  function renderLog(){
-    const items = loadLog();
-    if(!items.length){ logEl.innerHTML='No sets yet'; return; }
-    logEl.innerHTML = items.map(i=>`<div class="log-entry">Workout ${i.letter}: ${minsSec(presets.find(p=>p.seconds===state.seconds && p.sets===state.totalSets)?.seconds || state.seconds)} ×${state.totalSets} — ${i.time}</div>`).join('');
-  }
+  function renderLog(){
+    const items = loadLog();
+    if(!items.length){ logEl.innerHTML='No sets yet'; return; }
+    logEl.innerHTML = items.map(i=>
+      `<div class="log-entry">Workout ${i.letter}: ${minsSec(i.seconds)} ×${i.sets} — ${i.time}</div>`
+    ).join('');
+  }
   function logWorkout(){
     const items = loadLog();
     const letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ';


### PR DESCRIPTION
## Summary
- prevent timer control labels from wrapping by enforcing no-wrap button text
- allow control row to wrap and shrink primary button on narrow screens to keep buttons inside the card
- ensure each logged workout entry retains its recorded duration and set count

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6650ec9188331bc87ff25fe1e2caf